### PR TITLE
ISAPI Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This Web Application is a nice UI for all your hikvision cameras. It supports Lo
 * At the **SetEnv camNames** add a comma sepperated list of name the camera names which should be the same size as the camPaths.
 * At the **SetEnv camIPs** add a comma sepperated list of the IPs of each camera.
 * At the **SetEnv camAuths** add a comma sepperated list of the usernames/passwords for the authentication in this format: "admin:password"
+* At the **SetEnv camVersions** *(optional)* add a comma sepperated list of whether the Hikvision/HiLook cameras are on newer firmware and need /ISAPI/ paths. 0 for old, 1 for ISAPI/new - like "0,1" for an old and new camera, or "1,1" for two new cameras.
 
 
 ### Dependencies

--- a/dispatcher.php
+++ b/dispatcher.php
@@ -173,7 +173,7 @@
 
 					if (($camVersions[$index] ?? null) == 1) {
 						$ch = curl_init();
-						$url = 'http://'.$camIPs[$camIndex].'/ISAPI/Streaming/Channels/101/picture';
+						$url = 'http://'.$ip.'/ISAPI/Streaming/Channels/101/picture';
 						curl_setopt($ch, CURLOPT_URL, $url);
 						// curl_setopt($ch, CURLOPT_VERBOSE, true);
 						curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_DIGEST);


### PR DESCRIPTION
The current implementation of the live view pictures doesn't work on newer firmware where the URL changes from /Streaming/channels/102/picture to /ISAPI/Streaming/Channels/101/picture and required digest authentication instead of basic.

Added curl implementation for this and a variable to allow for mixed scenarios. Should be backwards compatible with the current .htaccess.